### PR TITLE
fix ModuleNotFoundError by renaming switrs_to_sqlite.py to main.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 # Get the version from the main script
 version = re.search(
     '^__version__\s*=\s*"(.*)"',
-    open("switrs_to_sqlite/switrs_to_sqlite.py").read(),
+    open("switrs_to_sqlite/main.py").read(),
     re.M,
 ).group(1)
 
@@ -35,7 +35,7 @@ setup(
     packages=["switrs_to_sqlite"],
     entry_points={
         "console_scripts": [
-            "switrs_to_sqlite = switrs_to_sqlite.switrs_to_sqlite:main"
+            "switrs_to_sqlite = switrs_to_sqlite.main:main"
         ],
     },
     classifiers=[

--- a/switrs_to_sqlite/main.py
+++ b/switrs_to_sqlite/main.py
@@ -9,7 +9,7 @@ from switrs_to_sqlite.parsers import CollisionRow, PartyRow, VictimRow
 
 
 # Library version
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 
 
 def main():


### PR DESCRIPTION
When attempting to checkout and run the tool directly out of a working copy, the name of the script conflicts with the module name and results in a ModuleNotFoundError. Renaming the script avoids that conflict.