### PR TITLE
allow user to specify handler for text decoder errors

### DIFF
--- a/switrs_to_sqlite/main.py
+++ b/switrs_to_sqlite/main.py
@@ -41,6 +41,12 @@ def main():
         help="the VictimRecords.txt file or the same file gzipped",
     )
     argparser.add_argument(
+        "-p",
+        "--parse-error",
+        help="how to handle parsing errors",
+        choices=["strict", "ignore", "replace"],
+    )
+    argparser.add_argument(
         "-o",
         "--output-file",
         help="file to save the database to",
@@ -62,7 +68,7 @@ def main():
             con.execute(RowClass.create_table_statement())
 
             # Read in the CSV and process each row
-            with open_record_file(file_name) as f:
+            with open_record_file(file_name, errors=args.parse_error) as f:
                 reader = csv.reader(f)
                 next(reader)  # Skip the header
 

--- a/switrs_to_sqlite/open_record.py
+++ b/switrs_to_sqlite/open_record.py
@@ -1,7 +1,7 @@
 import gzip
 
 
-def open_record_file(file_name):
+def open_record_file(file_name, errors=None):
     """Open a Record file, even if GZipped.
 
     Args:
@@ -10,5 +10,5 @@ def open_record_file(file_name):
 
     """
     if file_name.endswith(".gz"):
-        return gzip.open(file_name, "rt")
-    return open(file_name, "rt")
+        return gzip.open(file_name, "rt", errors=errors)
+    return open(file_name, "rt", errors=errors)


### PR DESCRIPTION
Somewhere in the past few years at least one row in `CollisionRecords.txt` contains a character that cannot be decoded with the default utf-8 codec.  As a result, the process fails:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd9 in position 3988: invalid continuation byte
```

This PR adds a command line flag that allows the user to specify the `errors` argument in `open()` and `gzip.open()`.

The command line flag is `-p`:

```
usage: switrs_to_sqlite [-h] [--version] [-p {strict,ignore,replace}] [-o OUTPUT_FILE]
                        collision_record party_record victim_record

Convert SWITRS text files to a SQLite3 database

positional arguments:
  collision_record      the CollisionRecords.txt file or the same file gzipped
  party_record          the PartyRecords.txt file or the same file gzipped
  victim_record         the VictimRecords.txt file or the same file gzipped

options:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  -p {strict,ignore,replace}, --parse-error {strict,ignore,replace}
                        how to handle parsing errors
  -o OUTPUT_FILE, --output-file OUTPUT_FILE
                        file to save the database to
```

and the default is None which results in "strict" error handling just as before. While technically there are other handlers available, these seemed sufficient for now.  I successfully imported a SWITRS dataset obtained yesterday with this patch.

Note: this PR depends on #13. 