### PR TITLE
Update CICD: Remove EOL Python versions and add new ones

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,16 +10,23 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy3']
+        python-version: 
+        - '3.8'
+        - '3.9'
+        - '3.10'
+        - '3.11'
+        - '3.12'
+        - 'pypy-3.9'
+        - 'pypy-3.10'
     name: Python ${{ matrix.python-version }} Test 🧪
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Dump GitHub context
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
     - name: Set up Python ${{ matrix.python-version }} 🐍
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies 🏗
@@ -41,13 +48,13 @@ jobs:
     needs: test
     name: Build Package 📦
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Dump GitHub context
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
     - name: Set up Python 🐍
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies 🏗

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,16 +8,23 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy3']
+        python-version: 
+        - '3.8'
+        - '3.9'
+        - '3.10'
+        - '3.11'
+        - '3.12'
+        - 'pypy-3.9'
+        - 'pypy-3.10'
     name: Python ${{ matrix.python-version }} Test 🧪
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Dump GitHub context
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
     - name: Set up Python ${{ matrix.python-version }} 🐍
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies 🏗

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,11 @@ setup(
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Utilities",
     ],
     keywords=[
@@ -62,5 +63,5 @@ setup(
         "pytest-runner",
     ],
     tests_require=["pytest"],
-    python_requires=">=3.6, <4",
+    python_requires=">=3.8, <4",
 )


### PR DESCRIPTION
3.6 and 3.7 are EOL, so remove.